### PR TITLE
Show the eval's output even if it's false.

### DIFF
--- a/lib/App/EvalServerAdvanced/Sandbox/Plugin/Perlbot.pm
+++ b/lib/App/EvalServerAdvanced/Sandbox/Plugin/Perlbot.pm
@@ -106,17 +106,22 @@ sub run_perl {
     }
     select STDOUT;
 
-    local $Data::Dumper::Terse = 1;
-    local $Data::Dumper::Quotekeys = 0;
-    local $Data::Dumper::Indent = 0;
-    local $Data::Dumper::Useqq = 1;
-    local $Data::Dumper::Freezer = "dd_freeze";
 
-    no warnings;
-    my $out = ref($ret) ? Dumper( $ret ) : "" . $ret;
 
-    print $out unless $outbuffer;
-    print $outbuffer;
+    if (length($outbuffer) > 0) {
+        print $outbuffer;
+    } else {
+        local $Data::Dumper::Terse = 1;
+        local $Data::Dumper::Quotekeys = 0;
+        local $Data::Dumper::Indent = 0;
+        local $Data::Dumper::Useqq = 1;
+        local $Data::Dumper::Freezer = "dd_freeze";
+
+        no warnings;
+        my $out = ref($ret) ? Dumper( $ret ) : "" . $ret;
+    
+      print $out;
+    }
 
     if( $err ) { print "ERROR: $err" }
 }


### PR DESCRIPTION
The code q{print "0"; "WOMBLE"} when evaluated produces stdout that evaluates to false.  Previously the output of an eval was tested for perl's idea of truth, and if found false, the return value of the eval was dumped.  This change checks the length of the output, and always shows the output if there was some output.

See freenode #perl 20171111 1813Z to 1822Z.